### PR TITLE
drivers/net/ethernet/freescale/Kconfig: fix FEC depends

### DIFF
--- a/drivers/net/ethernet/freescale/Kconfig
+++ b/drivers/net/ethernet/freescale/Kconfig
@@ -24,6 +24,7 @@ config FEC
 	tristate "FEC ethernet controller (of ColdFire and some i.MX CPUs)"
 	depends on (M523x || M527x || M5272 || M528x || M520x || M532x || \
 		   ARCH_MXC || ARCH_S32 || SOC_IMX28 || COMPILE_TEST)
+	depends on EEPROM_AT24
 	default ARCH_MXC || SOC_IMX28 if ARM
 	select CRC32
 	select PHYLIB


### PR DESCRIPTION
FEC now uses EEPROM_AT24 so it should `depends on` it.